### PR TITLE
chore: bump to 0.1.2 (republish with README screenshots)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-atlas",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Map and lint your .claude/ directory — agents, commands, tools, permissions as a navigable graph",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Ship the viewer screenshots to npmjs.com by republishing. No code changes.