### PR TITLE
chore: bump to 0.1.3 (republish with updated README)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-atlas",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Map and lint your .claude/ directory — agents, commands, tools, permissions as a navigable graph",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Ship the reordered screenshots (print1 hero + demo.gif secondary) to npmjs.com. No code changes.