### PR TITLE
feat: missing-description lint rule (closes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Agent→Agent delegation is detected by word-boundary matching on agent names in
 |---|---|---|
 | `dead-agent` | warning | Agent defined but never invoked by another agent or command |
 | `missing-agent-ref` | error | Command or agent mentions a name that doesn't exist |
+| `missing-description` | warning | Agent or command has no `description` in its frontmatter — hurts discoverability in pickers and sidebars |
 | `delegation-cycle` | warning | A invokes B invokes A |
 | `unused-tool-grant` | info | Agent has `Write` granted but its prose doesn't mention writing/editing |
 | `duplicate-candidate` | info | Two agents (or two commands) have overlapping prose + tools and may be worth merging |

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -52,6 +52,27 @@ export function lint(graph) {
     }
   }
 
+  for (const a of graph.agents) {
+    if (!a.description || !a.description.trim()) {
+      findings.push({
+        level: "warning",
+        code: "missing-description",
+        message: `Agent "${a.name}" has no description. Add one to the frontmatter so it's discoverable in tooling.`,
+        subject: `agent:${a.slug}`,
+      });
+    }
+  }
+  for (const c of graph.commands) {
+    if (!c.description || !c.description.trim()) {
+      findings.push({
+        level: "warning",
+        code: "missing-description",
+        message: `Command "/${c.slug}" has no description. Add frontmatter with a one-line description.`,
+        subject: `command:${c.slug}`,
+      });
+    }
+  }
+
   const cycles = detectCycles(graph);
   for (const cycle of cycles) {
     findings.push({

--- a/test/fixtures/sample/agents/no-description.md
+++ b/test/fixtures/sample/agents/no-description.md
@@ -1,0 +1,7 @@
+---
+name: no-description
+tools: [Read]
+---
+
+This agent intentionally omits the description field so the
+missing-description rule has something to flag.

--- a/test/fixtures/sample/commands/no-frontmatter.md
+++ b/test/fixtures/sample/commands/no-frontmatter.md
@@ -1,0 +1,6 @@
+Do something when invoked.
+
+$ARGUMENTS
+
+This command file has no frontmatter at all, so the scanner reports an
+empty description and the missing-description rule should flag it.


### PR DESCRIPTION
## Summary
- New warning-level lint rule `missing-description` — flags agents and commands whose frontmatter lacks a description field
- Applies to both agents and commands (shared rule, scoped by entity type in the message)

## Why
Descriptions surface in Claude Code's command picker and in `claude-atlas serve`'s sidebar. Missing ones silently degrade discoverability. We hand-audited this class across both claude-atlas and claude-code-vault earlier today and found 10 affected commands — exactly the pattern the linter should catch automatically.

## Changes
- `lib/linter.js`: new rule after `missing-agent-ref`, warning level
- `README.md`: rule added to the "Linters shipped" table
- `test/fixtures/sample/agents/no-description.md`: agent with frontmatter but no description — must fire
- `test/fixtures/sample/commands/no-frontmatter.md`: command with no frontmatter at all — must fire

## Verification
- [x] `node bin/cli.js lint .claude` → 0 `missing-description` warnings (every current agent/command has a description)
- [x] `node bin/cli.js lint test/fixtures/sample` → new rule fires on both fixture files (and on each entity type)

Closes #14