### PR TITLE
feat: permission blast-radius (closes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,25 @@ Rewrites the defining agent's frontmatter `name:` and every word-boundary mentio
 
 Filenames stay put for now — `agents/code-reviewer.md` keeps its name after renaming the agent inside. Rename the file yourself if you want the slug to move with it.
 
+### `claude-atlas who-can <permission> [path] [--deny]`
+
+```
+who can run: Bash(git push)
+
+  Allow rules matched:
+    - Bash(git *)
+
+1 agent(s):
+
+  shipper
+    tool grants: Bash
+    via rules:   Bash(git *)
+```
+
+Resolves a permission query — `Tool` or `Tool(spec)` — against `settings.json`'s `allow`/`deny` intersected with each agent's tool grants. `Bash(git push)` is allowed by `Bash(git *)` (glob match, `*` → `.*`). `--deny` inverts: `who-can "Bash(git push --force)" --deny` shows every agent a deny rule blocks — useful when reviewing a permission-widening PR ("if I add this deny, who loses what?").
+
+The viewer surfaces the same data in the sidebar: click an agent and you get a **Permissions** section listing every allow/deny rule applicable to that agent's tool grants, color-coded.
+
 ### `--json` everywhere
 
 ```bash
@@ -171,7 +190,7 @@ More on the [roadmap](#roadmap).
 - [x] **Interactive viewer** — cytoscape.js graph with details sidebar, served by Hono
 - [x] **Consolidation hints** — flag near-duplicate agents/commands via token + tool similarity
 - [x] **Rename-impact** — `claude-atlas rename <old> <new> --dry-run` rewrites the frontmatter and every word-boundary mention across `agents/` + `commands/`
-- [ ] **[Permission blast-radius](https://github.com/bernabranco/claude-atlas/issues/7)** — `claude-atlas who-can "Bash(git push)"`
+- [x] **Permission blast-radius** — `claude-atlas who-can "Bash(git push)"` lists every agent that can run the permission; `--deny` inverts; viewer sidebar surfaces applicable allow/deny rules per agent
 - [ ] **[Runtime overlay](https://github.com/bernabranco/claude-atlas/issues/8)** — parse session transcripts, show which edges actually fire
 - [ ] **[Markdown export](https://github.com/bernabranco/claude-atlas/issues/9)** — wiki-linked vault of the whole config
 - [ ] **[CI mode](https://github.com/bernabranco/claude-atlas/issues/10)** — annotate PRs with lint findings

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,11 +3,12 @@ import { scanClaudeDir } from "../lib/scanner.js";
 import { lint } from "../lib/linter.js";
 import { startServer } from "../lib/server.js";
 import { planRename, applyPlan } from "../lib/rename.js";
+import { whoCan } from "../lib/who-can.js";
 
 const args = process.argv.slice(2);
 const [command, ...rest] = args;
 
-const BOOLEAN_FLAGS = new Set(["json", "dryRun"]);
+const BOOLEAN_FLAGS = new Set(["json", "dryRun", "deny"]);
 
 function parseFlags(argv) {
   const flags = { positional: [] };
@@ -180,6 +181,60 @@ function truncate(s, n = 80) {
   return s.length > n ? `${s.slice(0, n - 1)}…` : s;
 }
 
+async function cmdWhoCan(argv) {
+  const flags = parseFlags(argv);
+  const [permission, pathArg] = flags.positional;
+
+  if (!permission) {
+    console.error('Usage: claude-atlas who-can <permission> [path] [--deny] [--json]');
+    console.error('  e.g. claude-atlas who-can "Bash(git push)"');
+    process.exit(1);
+  }
+
+  const target = pathArg || flags.claudeDir || ".claude";
+  const graph = await scanClaudeDir(target);
+  const result = whoCan(graph, permission, { denyMode: flags.deny });
+
+  if (flags.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  const mode = flags.deny ? "blocked from running" : "who can run";
+  console.log(`${mode}: ${result.permission}\n`);
+
+  if (result.allowedBy.length) {
+    console.log(`  Allow rules matched:`);
+    for (const r of result.allowedBy) console.log(`    - ${r}`);
+  } else if (!flags.deny) {
+    console.log(`  No allow rule matches "${result.permission}".`);
+  }
+  if (result.deniedBy.length) {
+    console.log(`  Deny rules matched:`);
+    for (const r of result.deniedBy) console.log(`    - ${r}`);
+  }
+
+  if (!result.agents.length) {
+    const why = flags.deny
+      ? "No agents blocked — no deny rule matches this permission."
+      : result.deniedBy.length && result.allowedBy.length
+      ? "No agents allowed — a deny rule blocks this permission. Re-run with --deny to see who's affected."
+      : result.allowedBy.length
+      ? "No agents have the required tool grant."
+      : "No agents allowed — no allow rule matches.";
+    console.log(`\n${why}`);
+    return;
+  }
+
+  console.log(`\n${result.agents.length} agent(s):\n`);
+  for (const a of result.agents) {
+    console.log(`  ${a.name}`);
+    console.log(`    tool grants: ${a.via.tools.join(", ")}`);
+    const rules = flags.deny ? a.via.deniedBy : a.via.allowedBy;
+    console.log(`    via rules:   ${rules.join(", ")}`);
+  }
+}
+
 function usage() {
   console.log(`claude-atlas — map and lint your .claude/ directory
 
@@ -197,6 +252,11 @@ Usage:
                                    Rename an agent and every reference to it.
                                    --dry-run prints the plan without writing.
 
+  claude-atlas who-can <permission> [path] [--deny] [--json]
+                                   List agents who can run a permission
+                                   (e.g. "Bash(git push)"). --deny inverts:
+                                   shows agents a deny rule blocks.
+
   claude-atlas serve [path]        Start the interactive graph viewer
   claude-atlas serve [path] --port 4000
                                    Choose the HTTP port (default 4000)
@@ -210,6 +270,7 @@ const handler = {
   lint: cmdLint,
   duplicates: cmdDuplicates,
   rename: cmdRename,
+  "who-can": cmdWhoCan,
   serve: cmdServe,
 }[command];
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { scanClaudeDir } from "./scanner.js";
 import { lint } from "./linter.js";
+import { whoCan, rulesForAgent } from "./who-can.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const webDir = path.resolve(__dirname, "..", "web");
@@ -15,6 +16,9 @@ export function createApp(claudeDir) {
   app.get("/api/graph", async (c) => {
     try {
       const graph = await scanClaudeDir(claudeDir);
+      for (const a of graph.agents) {
+        a.applicableRules = rulesForAgent(graph, a.slug);
+      }
       return c.json(graph);
     } catch (err) {
       return c.json({ error: err.message }, 500);
@@ -26,6 +30,18 @@ export function createApp(claudeDir) {
       const graph = await scanClaudeDir(claudeDir);
       const findings = lint(graph);
       return c.json(findings);
+    } catch (err) {
+      return c.json({ error: err.message }, 500);
+    }
+  });
+
+  app.get("/api/who-can", async (c) => {
+    try {
+      const permission = c.req.query("perm");
+      if (!permission) return c.json({ error: "missing ?perm=..." }, 400);
+      const denyMode = c.req.query("deny") === "1" || c.req.query("deny") === "true";
+      const graph = await scanClaudeDir(claudeDir);
+      return c.json(whoCan(graph, permission, { denyMode }));
     } catch (err) {
       return c.json({ error: err.message }, 500);
     }

--- a/lib/who-can.js
+++ b/lib/who-can.js
@@ -1,0 +1,128 @@
+/**
+ * Permission blast-radius: resolve Claude Code permission rules against the agent graph.
+ *
+ * Rule syntax reference: permissions are strings like "Tool" (bare — grants the
+ * whole tool) or "Tool(spec)" where spec is an fnmatch-style glob against the
+ * tool's argument string (e.g. "Bash(git *)"). deny overrides allow.
+ */
+
+/**
+ * Parse "Bash(git push)" → { tool: "Bash", spec: "git push" }.
+ * Bare "Read" → { tool: "Read", spec: null }.
+ */
+export function parsePermission(raw) {
+  const s = String(raw || "").trim();
+  const m = s.match(/^([^(]+)\((.*)\)\s*$/);
+  if (m) return { raw: s, tool: m[1].trim(), spec: m[2] };
+  return { raw: s, tool: s, spec: null };
+}
+
+/** fnmatch → regex: * → .*, ? → ., other regex metachars escaped. */
+function globToRegex(pattern) {
+  let out = "";
+  for (const ch of pattern) {
+    if (ch === "*") out += ".*";
+    else if (ch === "?") out += ".";
+    else if (/[.+^${}()|[\]\\]/.test(ch)) out += `\\${ch}`;
+    else out += ch;
+  }
+  return new RegExp(`^${out}$`);
+}
+
+/**
+ * Does `rule` cover `query`?
+ *
+ * Matching model:
+ * - Tools must match (case-insensitive).
+ * - Bare rule covers any scoped query for that tool ("Bash" covers "Bash(git push)").
+ * - Bare query against a scoped rule does NOT match — asking "who has full Bash?"
+ *   can't be answered yes by a rule that only grants a slice.
+ * - Both scoped: glob-match rule.spec against query.spec.
+ */
+export function ruleCovers(rule, query) {
+  if (rule.tool.toLowerCase() !== query.tool.toLowerCase()) return false;
+  if (rule.spec == null) return true;
+  if (query.spec == null) return false;
+  return globToRegex(rule.spec).test(query.spec);
+}
+
+/** Does an agent's frontmatter `tools` list cover this query's tool? */
+export function agentHasToolFor(agent, query) {
+  for (const raw of agent.tools || []) {
+    const grant = parsePermission(raw);
+    if (ruleCovers(grant, query)) return true;
+  }
+  return false;
+}
+
+/**
+ * Who can run `permission`?
+ *
+ * Returns { permission, query, allowedBy, deniedBy, agents }.
+ * An agent appears in `agents` iff: tool-grant covers query + some allow rule
+ * covers query + no deny rule covers query. With { denyMode: true }, returns
+ * agents who would otherwise match but are blocked by a deny rule.
+ */
+export function whoCan(graph, permission, { denyMode = false } = {}) {
+  const query = parsePermission(permission);
+  const allow = (graph.permissions?.allow || []).map(parsePermission);
+  const deny = (graph.permissions?.deny || []).map(parsePermission);
+
+  const allowedBy = allow.filter((r) => ruleCovers(r, query));
+  const deniedBy = deny.filter((r) => ruleCovers(r, query));
+
+  const agents = [];
+  for (const a of graph.agents) {
+    if (!agentHasToolFor(a, query)) continue;
+    const grants = (a.tools || []).filter((t) => ruleCovers(parsePermission(t), query));
+    if (denyMode) {
+      if (deniedBy.length) {
+        agents.push({
+          slug: a.slug,
+          name: a.name,
+          via: { tools: grants, deniedBy: deniedBy.map((r) => r.raw) },
+        });
+      }
+    } else {
+      if (allowedBy.length && !deniedBy.length) {
+        agents.push({
+          slug: a.slug,
+          name: a.name,
+          via: { tools: grants, allowedBy: allowedBy.map((r) => r.raw) },
+        });
+      }
+    }
+  }
+
+  return {
+    permission,
+    query,
+    allowedBy: allowedBy.map((r) => r.raw),
+    deniedBy: deniedBy.map((r) => r.raw),
+    agents,
+  };
+}
+
+/**
+ * Viewer helper: which allow/deny rules apply to this agent's tool grants?
+ *
+ * A rule "applies" if the agent has the tool it scopes. Doesn't try to
+ * answer "can this agent do X" — that's whoCan's job. Just filters the
+ * rule list down to the slice an operator needs to look at when thinking
+ * about this specific agent's blast radius.
+ */
+export function rulesForAgent(graph, agentSlug) {
+  const agent = graph.agents.find((a) => a.slug === agentSlug);
+  if (!agent) return { allowedBy: [], deniedBy: [] };
+
+  const agentTools = new Set(
+    (agent.tools || []).map((t) => parsePermission(t).tool.toLowerCase())
+  );
+  const scope = (rules) =>
+    rules.filter((r) => agentTools.has(parsePermission(r).tool.toLowerCase()));
+
+  return {
+    allowedBy: scope(graph.permissions?.allow || []),
+    deniedBy: scope(graph.permissions?.deny || []),
+  };
+}

--- a/test/fixtures/sample/agents/shipper.md
+++ b/test/fixtures/sample/agents/shipper.md
@@ -1,0 +1,9 @@
+---
+name: shipper
+description: Runs git + npm commands to cut releases.
+tools: [Bash, Read]
+---
+
+The shipper agent runs git and npm commands on behalf of the user. It
+reads the current state, proposes a version bump, and then runs the
+release commands. It never deletes anything, and it never force-pushes.

--- a/test/fixtures/sample/settings.json
+++ b/test/fixtures/sample/settings.json
@@ -1,6 +1,17 @@
 {
   "permissions": {
-    "allow": ["Read", "Grep", "Glob", "Edit", "Write(docs/**)"],
-    "deny": []
+    "allow": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Edit",
+      "Write(docs/**)",
+      "Bash(git *)",
+      "Bash(npm test)"
+    ],
+    "deny": [
+      "Bash(rm *)",
+      "Bash(git push --force*)"
+    ]
   }
 }

--- a/web/app.js
+++ b/web/app.js
@@ -496,6 +496,15 @@ function renderDetails(type, payload, id) {
       parts.push(sectionTitle("Invoked by", invokedBy.length));
       parts.push(`<div class="space-y-1.5">` + invokedBy.map(cardHTML).join("") + `</div>`);
     }
+    const rules = payload.applicableRules;
+    if (rules && (rules.allowedBy.length || rules.deniedBy.length)) {
+      const total = rules.allowedBy.length + rules.deniedBy.length;
+      parts.push(sectionTitle("Permissions", total));
+      parts.push(`<div class="flex flex-wrap gap-1.5">` +
+        rules.allowedBy.map((r) => rulePill(r, "allow")).join("") +
+        rules.deniedBy.map((r) => rulePill(r, "deny")).join("") +
+        `</div>`);
+    }
   }
 
   if (type === "tool") {
@@ -522,6 +531,16 @@ function sectionTitle(label, count) {
 
 function tagPill(label, dataId) {
   return `<span data-id="${dataId}" class="inline-flex items-center px-2 py-0.5 rounded border border-border bg-bg-2 text-[11.5px] text-fg cursor-pointer hover:border-border-2 hover:bg-panel-2 transition-colors">${escape(label)}</span>`;
+}
+
+function rulePill(rule, kind) {
+  const style = kind === "deny"
+    ? "border-[#ef4444]/50 bg-[#ef4444]/10 text-[#fca5a5]"
+    : "border-[#22c55e]/40 bg-[#22c55e]/10 text-[#86efac]";
+  const glyph = kind === "deny" ? "✕" : "✓";
+  return `<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded border ${style} text-[11.5px] font-mono">
+    <span class="opacity-70">${glyph}</span>${escape(rule)}
+  </span>`;
 }
 
 function cardHTML(id) {


### PR DESCRIPTION
## Summary

Second wedge feature — resolves a Claude Code permission query (`Tool` or `Tool(spec)`) against `settings.json` allow/deny intersected with each agent's tool grants.

### CLI

```bash
$ claude-atlas who-can "Bash(git push)" test/fixtures/sample
who can run: Bash(git push)

  Allow rules matched:
    - Bash(git *)

1 agent(s):

  shipper
    tool grants: Bash
    via rules:   Bash(git *)
```

\`--deny\` inverts: shows every agent a deny rule blocks. Answers "if I add this deny rule, who loses what?"

\`--json\` emits structured `{ permission, query, allowedBy, deniedBy, agents: [{slug, name, via}] }` for scripting.

### Viewer

Click an agent → sidebar gets a **Permissions** section with color-coded pills (allow = green ✓, deny = red ✕) for every rule applicable to the agent's tool grants. Same logic as the CLI, surfaced inline.

### How it matches

- **Bare rule** (`Bash`) covers any scoped query (`Bash(anything)`)
- **Scoped rule** (`Bash(git *)`) only covers matching scoped queries; `*` → `.*`, `?` → `.`, other regex metachars escaped
- **Deny overrides allow** — an agent is "allowed" iff tool grant covers + some allow matches + **no** deny matches
- Case-insensitive on the tool name

## Files

| File | Change |
|---|---|
| \`lib/who-can.js\` (new) | Core resolver: `parsePermission`, `globToRegex`, `ruleCovers`, `agentHasToolFor`, `whoCan`, `rulesForAgent` |
| \`bin/cli.js\` | Wires \`who-can\` subcommand |
| \`lib/server.js\` | Augments \`/api/graph\` agent payload with \`applicableRules\`; adds \`/api/who-can?perm=...&deny=0|1\` |
| \`web/app.js\` | New \`rulePill()\`; Permissions section in agent sidebar |
| \`test/fixtures/sample/settings.json\` | Realistic allow/deny: \`Bash(git *)\`, \`Bash(npm test)\`, deny \`Bash(rm *)\` + \`Bash(git push --force*)\` |
| \`test/fixtures/sample/agents/shipper.md\` | New Bash-using agent to exercise all three paths |
| \`README.md\` | New section + roadmap ticked |

## Scope notes

- **fnmatch, not full shell glob.** Complex patterns from the wild (e.g. `Bash(git commit -m ':*)`) will over-match — documented as a v1 limitation.
- **Viewer** surfaces the *agent-centric* view (rules applicable to this agent). The CLI surfaces the *rule-centric* view (agents allowed by this permission). Both share the same resolver.
- No changes to the graph node set — the viewer stays agent/command/tool/MCP-centric. Permissions surface in the sidebar only.

## Test plan

- [x] \`who-can "Bash(git push)"\` — 1 agent (shipper via Bash(git *))
- [x] \`who-can "Bash(git push --force)"\` — 0 agents, message points to \`--deny\`
- [x] Same with \`--deny\` — shipper, via deny Bash(git push --force*)
- [x] \`who-can "Bash(rm -rf /)"\` — 0 agents, no allow rule matches
- [x] \`who-can "Read"\` — all 5 agents (bare-tool lists every Read-granted agent)
- [x] Path with no settings.json (atlas's own \`.claude/\`) — no crash, "no allow rule matches"
- [x] \`/api/graph\` agent payloads now carry \`applicableRules: { allowedBy, deniedBy }\`
- [x] \`/api/who-can?perm=...&deny=1\` returns the expected JSON
- [x] \`--json\` shape stable
- [ ] **Manual browser check:** click \"shipper\" in the viewer, confirm Permissions section renders three green + two red pills

Closes #7