### PR TITLE
feat: CI mode — lint --format github + init-ci (closes #10)

### DIFF
--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -1,0 +1,30 @@
+---
+description: Code review + merge an existing PR on claude-atlas
+argument-hint: "<pr-number>"
+---
+
+Review and merge PR #$ARGUMENTS on `bernabranco/claude-atlas`.
+
+Steps:
+
+1. **Preflight** — Run `git status --short`. If the working tree is dirty, stop and ask the user to stash or commit before continuing. Never stash automatically.
+
+2. **Inspect** — `gh pr view $ARGUMENTS --repo bernabranco/claude-atlas --json state,mergeable,statusCheckRollup,headRefName,title`.
+   - `state` must be `OPEN`.
+   - `mergeable` must be `MERGEABLE` (not `CONFLICTING` or `UNKNOWN`).
+   - Every check in `statusCheckRollup` must be `SUCCESS`.
+   - Stop and report on any failure.
+
+3. **Checkout** — `gh pr checkout $ARGUMENTS --repo bernabranco/claude-atlas`. Confirm HEAD matches the PR's `headRefName`.
+
+4. **Changed files** — `gh pr diff $ARGUMENTS --repo bernabranco/claude-atlas --name-only`. Show the list.
+
+5. **Code review** — Invoke the `code-reviewer` agent: "Review PR #$ARGUMENTS on claude-atlas. Files: [list]. Be strict — this is a published npm package. Flag critical/high as blockers, medium as warnings. Apply the surface-specific checklist for each file."
+
+6. **Gate** — If any critical or high findings, stop. Post the findings as a PR comment via `gh pr comment $ARGUMENTS --repo bernabranco/claude-atlas --body "..."` and ask the user how to proceed. Do not merge.
+
+7. **Merge** — Hand off to the `release-manager` agent: "Merge PR #$ARGUMENTS on `bernabranco/claude-atlas` using `gh pr merge $ARGUMENTS --repo bernabranco/claude-atlas --merge --delete-branch`. Respect the hard rules — no squash, no force-push, never `--no-verify`. If branch protection blocks, surface the error and ask before using `--admin`."
+
+8. **Restore** — `git checkout main && git pull --ff-only origin main`.
+
+Report: PR title, merged commit SHA, link, and any review findings that were below the blocker threshold (so the user knows what was not blocking but worth seeing).

--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -1,0 +1,27 @@
+name: claude-atlas
+
+on:
+  pull_request:
+    paths:
+      - ".claude/**"
+      - ".mcp.json"
+      - "bin/**"
+      - "lib/**"
+      - ".github/workflows/atlas.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".claude/**"
+      - ".mcp.json"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install --no-audit --no-fund
+      - name: Lint .claude/ (self-dogfood from source)
+        run: node bin/cli.js lint .claude --format github

--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ Resolves a permission query — `Tool` or `Tool(spec)` — against `settings.jso
 
 The viewer surfaces the same data in the sidebar: click an agent and you get a **Permissions** section listing every allow/deny rule applicable to that agent's tool grants, color-coded.
 
+### `claude-atlas lint --format github` + `claude-atlas init-ci`
+
+Run the linter on every PR without setting up a token or a third-party action.
+
+```bash
+claude-atlas init-ci
+# ✓ Wrote .github/workflows/atlas.yml
+git add .github/workflows/atlas.yml && git commit -m "chore: add claude-atlas CI" && git push
+```
+
+The scaffolded workflow runs on any PR or push that touches `.claude/` or `.mcp.json` and executes:
+
+```bash
+npx --yes claude-atlas lint .claude --format github
+```
+
+`--format github` emits [GitHub Actions workflow commands](https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions) — one per finding — which GitHub parses from stdout and renders as inline PR annotations pinned to the offending file. `missing-agent-ref` (error) fails the check; `dead-agent`, `missing-description`, `delegation-cycle` (warning) and `unused-tool-grant`, `duplicate-candidate` (info) surface as annotations but don't block the merge.
+
+No `GITHUB_TOKEN` setup required — workflow commands are rendered from stdout, not through the API. If the file already exists, `init-ci` refuses; pass `--force` to overwrite.
+
 ### `--json` everywhere
 
 ```bash
@@ -193,7 +213,7 @@ More on the [roadmap](#roadmap).
 - [x] **Permission blast-radius** — `claude-atlas who-can "Bash(git push)"` lists every agent that can run the permission; `--deny` inverts; viewer sidebar surfaces applicable allow/deny rules per agent
 - [ ] **[Runtime overlay](https://github.com/bernabranco/claude-atlas/issues/8)** — parse session transcripts, show which edges actually fire
 - [ ] **[Markdown export](https://github.com/bernabranco/claude-atlas/issues/9)** — wiki-linked vault of the whole config
-- [ ] **[CI mode](https://github.com/bernabranco/claude-atlas/issues/10)** — annotate PRs with lint findings
+- [x] **CI mode** — `claude-atlas lint --format github` emits PR annotations; `claude-atlas init-ci` scaffolds `.github/workflows/atlas.yml`
 
 ## Contributing
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,11 +4,14 @@ import { lint } from "../lib/linter.js";
 import { startServer } from "../lib/server.js";
 import { planRename, applyPlan } from "../lib/rename.js";
 import { whoCan } from "../lib/who-can.js";
+import { formatFindingsGitHub } from "../lib/formatters.js";
+import { initCi } from "../lib/init-ci.js";
+import path from "path";
 
 const args = process.argv.slice(2);
 const [command, ...rest] = args;
 
-const BOOLEAN_FLAGS = new Set(["json", "dryRun", "deny"]);
+const BOOLEAN_FLAGS = new Set(["json", "dryRun", "deny", "force"]);
 
 function parseFlags(argv) {
   const flags = { positional: [] };
@@ -62,10 +65,16 @@ async function cmdLint(argv) {
   const target = flags.claudeDir || flags.positional[0] || ".claude";
   const graph = await scanClaudeDir(target);
   const findings = lint(graph);
+  const hasErrors = findings.some((f) => f.level === "error");
+
+  if (flags.format === "github") {
+    for (const line of formatFindingsGitHub(findings, graph)) console.log(line);
+    process.exit(hasErrors ? 1 : 0);
+  }
 
   if (flags.json) {
     console.log(JSON.stringify(findings, null, 2));
-    process.exit(findings.some((f) => f.level === "error") ? 1 : 0);
+    process.exit(hasErrors ? 1 : 0);
   }
 
   if (!findings.length) {
@@ -235,6 +244,22 @@ async function cmdWhoCan(argv) {
   }
 }
 
+async function cmdInitCi(argv) {
+  const flags = parseFlags(argv);
+  const result = await initCi({ force: Boolean(flags.force) });
+  const rel = path.relative(process.cwd(), result.path) || result.path;
+
+  if (result.existed && !result.written) {
+    console.error(`✗ ${rel} already exists. Re-run with --force to overwrite.`);
+    process.exit(1);
+  }
+  console.log(`✓ Wrote ${rel}`);
+  console.log(`\nNext steps:`);
+  console.log(`  1. Commit ${rel}`);
+  console.log(`  2. Push — the workflow runs on PRs touching .claude/ or .mcp.json`);
+  console.log(`  3. Findings appear as PR annotations; errors fail the check`);
+}
+
 function usage() {
   console.log(`claude-atlas — map and lint your .claude/ directory
 
@@ -244,6 +269,9 @@ Usage:
 
   claude-atlas lint [path]         Lint the graph for issues
   claude-atlas lint [path] --json  Emit findings as JSON (exit 1 on errors)
+  claude-atlas lint [path] --format github
+                                   Emit GitHub Actions workflow commands
+                                   (PR annotations); exit 1 on errors
 
   claude-atlas duplicates [path]   Show only duplicate-candidate findings,
                                    ranked by similarity score
@@ -256,6 +284,10 @@ Usage:
                                    List agents who can run a permission
                                    (e.g. "Bash(git push)"). --deny inverts:
                                    shows agents a deny rule blocks.
+
+  claude-atlas init-ci [--force]   Scaffold .github/workflows/atlas.yml so
+                                   the linter runs on every PR. --force
+                                   overwrites an existing file.
 
   claude-atlas serve [path]        Start the interactive graph viewer
   claude-atlas serve [path] --port 4000
@@ -271,6 +303,7 @@ const handler = {
   duplicates: cmdDuplicates,
   rename: cmdRename,
   "who-can": cmdWhoCan,
+  "init-ci": cmdInitCi,
   serve: cmdServe,
 }[command];
 

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -1,0 +1,49 @@
+/**
+ * Output formatters for lint findings.
+ *
+ * GitHub Actions workflow commands are the simplest way to render findings
+ * as PR annotations — GitHub parses `::level file=...::message` lines from
+ * step stdout and attaches them to the commit. No API calls, no tokens.
+ *
+ * Spec: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions
+ */
+import path from "path";
+
+const LEVEL_TO_CMD = {
+  error: "error",
+  warning: "warning",
+  info: "notice",
+};
+
+/** GitHub requires %/\r/\n escaped in workflow-command message bodies. */
+function escapeMessage(msg) {
+  return String(msg).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+function resolveFile(graph, subject) {
+  if (!subject) return null;
+  const [kind, slug] = subject.split(":");
+  if (kind === "agent") return graph.agents.find((a) => a.slug === slug)?.file || null;
+  if (kind === "command") return graph.commands.find((c) => c.slug === slug)?.file || null;
+  return null;
+}
+
+/**
+ * Emit findings as GitHub Actions workflow commands.
+ * Returns an array of strings — one command per finding. Caller prints them.
+ *
+ * Without a resolvable file, the annotation is still emitted but unattached
+ * (GitHub shows it at the top of the job log). This keeps every finding
+ * visible; losing one silently is worse than an unattached annotation.
+ */
+export function formatFindingsGitHub(findings, graph, { cwd = process.cwd() } = {}) {
+  const lines = [];
+  for (const f of findings) {
+    const cmd = LEVEL_TO_CMD[f.level] || "notice";
+    const abs = resolveFile(graph, f.subject);
+    const props = [`title=claude-atlas/${f.code}`];
+    if (abs) props.unshift(`file=${path.relative(cwd, abs)}`);
+    lines.push(`::${cmd} ${props.join(",")}::${escapeMessage(f.message)}`);
+  }
+  return lines;
+}

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -42,7 +42,13 @@ export function formatFindingsGitHub(findings, graph, { cwd = process.cwd() } = 
     const cmd = LEVEL_TO_CMD[f.level] || "notice";
     const abs = resolveFile(graph, f.subject);
     const props = [`title=claude-atlas/${f.code}`];
-    if (abs) props.unshift(`file=${path.relative(cwd, abs)}`);
+    if (abs) {
+      const parts = [`file=${path.relative(cwd, abs)}`];
+      // `line=` is what pins the annotation inline on the PR's Files Changed tab.
+      // Without it, GitHub only shows the annotation in the job summary.
+      if (Number.isInteger(f.line) && f.line > 0) parts.push(`line=${f.line}`);
+      props.unshift(...parts);
+    }
     lines.push(`::${cmd} ${props.join(",")}::${escapeMessage(f.message)}`);
   }
   return lines;

--- a/lib/init-ci.js
+++ b/lib/init-ci.js
@@ -1,0 +1,52 @@
+/**
+ * Scaffold a GitHub Actions workflow that runs `claude-atlas lint --format github`
+ * on every PR and push. Users drop it in, commit, done — no token setup,
+ * GITHUB_TOKEN is auto-injected by the runner and workflow-command annotations
+ * are rendered from stdout without any API call.
+ */
+import fs from "fs/promises";
+import path from "path";
+
+const WORKFLOW_PATH = ".github/workflows/atlas.yml";
+
+const WORKFLOW_TEMPLATE = `name: claude-atlas
+
+on:
+  pull_request:
+    paths:
+      - ".claude/**"
+      - ".mcp.json"
+  push:
+    branches: [main]
+    paths:
+      - ".claude/**"
+      - ".mcp.json"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Lint .claude/
+        run: npx --yes claude-atlas lint .claude --format github
+`;
+
+export async function initCi({ cwd = process.cwd(), force = false } = {}) {
+  const target = path.join(cwd, WORKFLOW_PATH);
+  let existed = false;
+  try {
+    await fs.access(target);
+    existed = true;
+  } catch {
+    // missing — good
+  }
+  if (existed && !force) {
+    return { written: false, existed: true, path: target };
+  }
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.writeFile(target, WORKFLOW_TEMPLATE, "utf-8");
+  return { written: true, existed, path: target };
+}

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -23,6 +23,7 @@ export function lint(graph) {
         code: "dead-agent",
         message: `Agent "${a.name}" is never invoked by another agent or command.`,
         subject: `agent:${a.slug}`,
+        line: a.lines?.name ?? 1,
       });
     }
   }
@@ -35,6 +36,7 @@ export function lint(graph) {
           code: "missing-agent-ref",
           message: `Agent "${a.name}" references unknown agent "${invoked}".`,
           subject: `agent:${a.slug}`,
+          line: a.lines?.name ?? 1,
         });
       }
     }
@@ -47,6 +49,7 @@ export function lint(graph) {
           code: "missing-agent-ref",
           message: `Command "/${c.slug}" references unknown agent "${invoked}".`,
           subject: `command:${c.slug}`,
+          line: c.lines?.name ?? 1,
         });
       }
     }
@@ -59,6 +62,7 @@ export function lint(graph) {
         code: "missing-description",
         message: `Agent "${a.name}" has no description. Add one to the frontmatter so it's discoverable in tooling.`,
         subject: `agent:${a.slug}`,
+        line: a.lines?.name ?? 1,
       });
     }
   }
@@ -69,17 +73,21 @@ export function lint(graph) {
         code: "missing-description",
         message: `Command "/${c.slug}" has no description. Add frontmatter with a one-line description.`,
         subject: `command:${c.slug}`,
+        line: c.lines?.name ?? 1,
       });
     }
   }
 
+  const agentBySlug = new Map(graph.agents.map((a) => [a.slug, a]));
   const cycles = detectCycles(graph);
   for (const cycle of cycles) {
+    const first = agentBySlug.get(cycle[0]);
     findings.push({
       level: "warning",
       code: "delegation-cycle",
       message: `Delegation cycle: ${cycle.join(" → ")} → ${cycle[0]}`,
       subject: `agent:${cycle[0]}`,
+      line: first?.lines?.name ?? 1,
     });
   }
 
@@ -94,6 +102,7 @@ export function lint(graph) {
         code: "unused-tool-grant",
         message: `Agent "${a.name}" has the Write tool but its prose doesn't mention writing or editing files.`,
         subject: `agent:${a.slug}`,
+        line: a.lines?.tools ?? a.lines?.name ?? 1,
       });
     }
   }
@@ -139,6 +148,7 @@ function detectDuplicateAgents(agents) {
     name: a.name,
     tokens: tokenize(`${a.name} ${a.description} ${a.body || ""}`),
     tools: new Set((a.tools || []).map((t) => t.toLowerCase())),
+    line: a.lines?.name ?? 1,
   }));
 
   const findings = [];
@@ -155,6 +165,7 @@ function detectDuplicateAgents(agents) {
           subject: `agent:${enriched[i].slug}`,
           related: [`agent:${enriched[j].slug}`],
           score: Number(score.toFixed(3)),
+          line: enriched[i].line,
         });
       }
     }
@@ -169,6 +180,7 @@ function detectDuplicateCommands(commands) {
     slug: c.slug,
     name: c.name,
     tokens: tokenize(`${c.name} ${c.description} ${c.body || ""}`),
+    line: c.lines?.name ?? 1,
   }));
 
   const findings = [];
@@ -183,6 +195,7 @@ function detectDuplicateCommands(commands) {
           subject: `command:${enriched[i].slug}`,
           related: [`command:${enriched[j].slug}`],
           score: Number(score.toFixed(3)),
+          line: enriched[i].line,
         });
       }
     }

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -7,8 +7,9 @@ async function readMdFiles(dir) {
     const files = [];
     for (const e of entries) {
       if (e.isFile() && e.name.endsWith(".md")) {
-        const content = await fs.readFile(path.join(dir, e.name), "utf-8");
-        files.push({ name: e.name.replace(/\.md$/, ""), content });
+        const filePath = path.join(dir, e.name);
+        const content = await fs.readFile(filePath, "utf-8");
+        files.push({ name: e.name.replace(/\.md$/, ""), content, file: filePath });
       }
     }
     return files;
@@ -101,6 +102,7 @@ export async function scanClaudeDir(claudeDir) {
       description: frontmatter.description || "",
       tools: frontmatter.tools || [],
       body: body.trim(),
+      file: f.file,
     };
   });
 
@@ -111,6 +113,7 @@ export async function scanClaudeDir(claudeDir) {
       name: frontmatter.name || f.name,
       description: frontmatter.description || "",
       body: body.trim(),
+      file: f.file,
     };
   });
 

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -20,21 +20,31 @@ async function readMdFiles(dir) {
 
 function parseFrontmatter(content) {
   const match = content.match(/^---\n([\s\S]*?)\n---\n/);
-  if (!match) return { frontmatter: {}, body: content };
+  if (!match) return { frontmatter: {}, body: content, bodyLine: 1, fmLines: {} };
   const fm = {};
-  for (const line of match[1].split("\n")) {
+  const fmLines = {};
+  match[1].split("\n").forEach((line, i) => {
+    // Line 1 in the file is the opening "---"; frontmatter content starts at line 2.
+    const fileLine = i + 2;
     const [key, ...rest] = line.split(":");
-    if (!key || !rest.length) continue;
+    if (!key || !rest.length) return;
     const value = rest.join(":").trim();
     const k = key.trim();
-    if (k === "name") fm.name = value.replace(/^["']|["']$/g, "");
-    else if (k === "description") fm.description = value.replace(/^["']|["']$/g, "");
-    else if (k === "tools") {
+    if (k === "name") {
+      fm.name = value.replace(/^["']|["']$/g, "");
+      fmLines.name = fileLine;
+    } else if (k === "description") {
+      fm.description = value.replace(/^["']|["']$/g, "");
+      fmLines.description = fileLine;
+    } else if (k === "tools") {
       const inner = value.match(/\[(.*?)\]/)?.[1] ?? "";
       fm.tools = inner.split(",").map((t) => t.trim()).filter(Boolean);
+      fmLines.tools = fileLine;
     }
-  }
-  return { frontmatter: fm, body: content.slice(match[0].length) };
+  });
+  // Body begins on the line immediately after the closing "---\n".
+  const bodyLine = (match[0].match(/\n/g) || []).length + 1;
+  return { frontmatter: fm, body: content.slice(match[0].length), bodyLine, fmLines };
 }
 
 function slug(s) {
@@ -95,7 +105,7 @@ export async function scanClaudeDir(claudeDir) {
   const permissions = await readSettingsPermissions(absClaude);
 
   const agents = rawAgents.map((f) => {
-    const { frontmatter, body } = parseFrontmatter(f.content);
+    const { frontmatter, body, fmLines } = parseFrontmatter(f.content);
     return {
       slug: slug(f.name),
       name: frontmatter.name || f.name,
@@ -103,17 +113,28 @@ export async function scanClaudeDir(claudeDir) {
       tools: frontmatter.tools || [],
       body: body.trim(),
       file: f.file,
+      lines: {
+        // `name` falls back to line 1 so findings always have a clickable anchor,
+        // even for files without frontmatter.
+        name: fmLines.name || 1,
+        description: fmLines.description || null,
+        tools: fmLines.tools || null,
+      },
     };
   });
 
   const commands = rawCommands.map((f) => {
-    const { frontmatter, body } = parseFrontmatter(f.content);
+    const { frontmatter, body, fmLines } = parseFrontmatter(f.content);
     return {
       slug: slug(f.name),
       name: frontmatter.name || f.name,
       description: frontmatter.description || "",
       body: body.trim(),
       file: f.file,
+      lines: {
+        name: fmLines.name || 1,
+        description: fmLines.description || null,
+      },
     };
   });
 


### PR DESCRIPTION
## Summary

- **`claude-atlas lint [path] --format github`** — emits [GitHub Actions workflow commands](https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions) so findings render as inline PR annotations. `error` → fails the check; `warning`/`info` → surface as annotations without blocking.
- **`claude-atlas init-ci`** — scaffolds `.github/workflows/atlas.yml` in the caller's repo. Refuses to overwrite; `--force` opts in.
- **Scanner** — agents/commands now carry an absolute `file` path so the formatter can map findings back to source.
- **Self-dogfood** — `.github/workflows/atlas.yml` runs atlas from source against its own `.claude/` on every PR that touches `.claude/`, `bin/`, or `lib/`.

No `GITHUB_TOKEN` setup required — workflow commands are rendered from stdout, not through the API.

Closes #10.

## Test plan
- [x] `node bin/cli.js lint test/fixtures/sample --format github` emits workflow commands with resolved file paths
- [x] `claude-atlas init-ci` writes `.github/workflows/atlas.yml` to a fresh dir; re-run without `--force` refuses; re-run with `--force` overwrites
- [x] `node bin/cli.js lint .claude --format github` on atlas's own config exits 0 with 2 notices
- [ ] Self-dogfood workflow run on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)