### PR TITLE
feat: invocation order in graph + viewer (closes #22)

### DIFF
--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -104,13 +104,16 @@ export async function scanClaudeDir(claudeDir) {
   const mcpServers = await readMcpServers(repoRoot);
   const permissions = await readSettingsPermissions(absClaude);
 
-  const agents = rawAgents.map((f) => {
-    const { frontmatter, body, fmLines } = parseFrontmatter(f.content);
-    return {
+  function buildDoc(f, includeTools) {
+    const { frontmatter, body, fmLines, bodyLine } = parseFrontmatter(f.content);
+    // `body` from parseFrontmatter starts at `bodyLine`. We trim for display,
+    // but shift `lines.body` forward by however many blank lines the trim ate
+    // so mention-line math downstream is correct.
+    const leading = (body.match(/^\n*/) || [""])[0].length;
+    const doc = {
       slug: slug(f.name),
       name: frontmatter.name || f.name,
       description: frontmatter.description || "",
-      tools: frontmatter.tools || [],
       body: body.trim(),
       file: f.file,
       lines: {
@@ -118,36 +121,42 @@ export async function scanClaudeDir(claudeDir) {
         // even for files without frontmatter.
         name: fmLines.name || 1,
         description: fmLines.description || null,
-        tools: fmLines.tools || null,
+        body: bodyLine + leading,
       },
     };
-  });
+    if (includeTools) {
+      doc.tools = frontmatter.tools || [];
+      doc.lines.tools = fmLines.tools || null;
+    }
+    return doc;
+  }
 
-  const commands = rawCommands.map((f) => {
-    const { frontmatter, body, fmLines } = parseFrontmatter(f.content);
-    return {
-      slug: slug(f.name),
-      name: frontmatter.name || f.name,
-      description: frontmatter.description || "",
-      body: body.trim(),
-      file: f.file,
-      lines: {
-        name: fmLines.name || 1,
-        description: fmLines.description || null,
-      },
-    };
-  });
+  const agents = rawAgents.map((f) => buildDoc(f, true));
+  const commands = rawCommands.map((f) => buildDoc(f, false));
 
   const agentByLowerName = new Map(agents.map((a) => [a.name.toLowerCase(), a]));
 
-  function detectAgentMentions(body, selfSlug = null) {
-    const hits = new Set();
+  /**
+   * Find first-occurrence line of each mentioned agent in `body`, return
+   * [{slug, line}] sorted by line. Scanning line-by-line (instead of a
+   * single regex against the whole body) is what gives us the ordering.
+   */
+  function detectAgentMentions(body, bodyLine, selfSlug = null) {
+    const hits = new Map();
+    const bodyLines = body.split("\n");
     for (const [nameLower, agent] of agentByLowerName) {
       if (agent.slug === selfSlug) continue;
       const re = new RegExp(`\\b${escapeRegex(nameLower)}\\b`, "i");
-      if (re.test(body)) hits.add(agent.slug);
+      for (let i = 0; i < bodyLines.length; i++) {
+        if (re.test(bodyLines[i])) {
+          hits.set(agent.slug, bodyLine + i);
+          break;
+        }
+      }
     }
-    return [...hits];
+    return [...hits.entries()]
+      .map(([slug, line]) => ({ slug, line }))
+      .sort((a, b) => a.line - b.line);
   }
 
   const toolGrants = new Map();
@@ -159,8 +168,16 @@ export async function scanClaudeDir(claudeDir) {
     }
   }
 
-  for (const a of agents) a.invokes = detectAgentMentions(a.body, a.slug);
-  for (const c of commands) c.invokes = detectAgentMentions(c.body);
+  for (const a of agents) {
+    const ordered = detectAgentMentions(a.body, a.lines.body, a.slug);
+    a.invokesOrdered = ordered;
+    a.invokes = ordered.map((h) => h.slug);
+  }
+  for (const c of commands) {
+    const ordered = detectAgentMentions(c.body, c.lines.body);
+    c.invokesOrdered = ordered;
+    c.invokes = ordered.map((h) => h.slug);
+  }
 
   const edges = [];
   for (const a of agents) {

--- a/web/app.js
+++ b/web/app.js
@@ -487,7 +487,7 @@ function renderDetails(type, payload, id) {
     }
     if (payload.invokes?.length) {
       parts.push(sectionTitle("Invokes", payload.invokes.length));
-      parts.push(`<div class="space-y-1.5">` + payload.invokes.map((s) => cardHTML(`agent:${s}`)).join("") + `</div>`);
+      parts.push(`<div class="space-y-1.5">` + invokeListHTML(payload) + `</div>`);
     }
     const invokedBy = graph.edges
       .filter((e) => e.to === `agent:${payload.slug}` && e.kind === "invokes")
@@ -515,7 +515,7 @@ function renderDetails(type, payload, id) {
   if (type === "command") {
     if (payload.invokes?.length) {
       parts.push(sectionTitle("Invokes", payload.invokes.length));
-      parts.push(`<div class="space-y-1.5">` + payload.invokes.map((s) => cardHTML(`agent:${s}`)).join("") + `</div>`);
+      parts.push(`<div class="space-y-1.5">` + invokeListHTML(payload) + `</div>`);
     }
   }
 
@@ -541,6 +541,23 @@ function rulePill(rule, kind) {
   return `<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded border ${style} text-[11.5px] font-mono">
     <span class="opacity-70">${glyph}</span>${escape(rule)}
   </span>`;
+}
+
+/**
+ * Render the Invokes list. When there are ≥2 mentions we prefix each card
+ * with its source-order index (1., 2., …) so readers see the recipe order
+ * for orchestration commands / agents. A single invocation is left plain.
+ */
+function invokeListHTML(payload) {
+  const ordered = payload.invokesOrdered || (payload.invokes || []).map((slug) => ({ slug }));
+  const numbered = ordered.length >= 2;
+  return ordered
+    .map((h, i) => {
+      const card = cardHTML(`agent:${h.slug}`);
+      if (!numbered) return card;
+      return `<div class="flex items-start gap-2"><span class="text-xs text-muted mt-2 font-mono tabular-nums shrink-0">${i + 1}.</span><div class="flex-1">${card}</div></div>`;
+    })
+    .join("");
 }
 
 function cardHTML(id) {


### PR DESCRIPTION
## Summary

- Scanner returns mentions in source order and exposes them as \`invokesOrdered: [{slug, line}]\` on every agent and command. \`invokes\` (string array) is unchanged for backward compat.
- Viewer sidebar prefixes each Invokes-list card with its source-order index (\`1.\`, \`2.\`, …) when there are ≥2 mentions. Single invocations stay plain.
- Each doc gains \`lines.body\` so downstream line math is correct even when the body has leading blank lines after frontmatter.

## Why

Commands and agents that orchestrate multiple others are linear recipes. Before this, the sidebar showed the invocation list as an unordered set — you couldn't tell which agent runs first just by clicking the node.

## Example

Given \`agents/planner.md\`:
\`\`\`
---
name: planner
---
The planner produces a short implementation plan. When the plan is ready
it hands the plan to the reviewer for a sanity check, and only after the
reviewer signs off does the writer start editing anything.
\`\`\`

\`scan . --json\` now emits:
\`\`\`json
\"invokesOrdered\": [
  {\"slug\": \"reviewer\", \"line\": 8},
  {\"slug\": \"writer\",   \"line\": 9}
]
\`\`\`

Sidebar renders:
\`\`\`
Invokes (2)
  1. reviewer
  2. writer
\`\`\`

Closes #22.

## Test plan
- [x] \`scan --json\` shows \`invokesOrdered\` on agents and commands, sorted by line
- [x] \`lint --format github\` still passes on fixtures
- [x] Viewer API returns \`invokesOrdered\` (verified via curl)
- [ ] CI green on push
- [ ] Self-dogfood workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)