### PR TITLE
feat: click-to-edit rename from viewer sidebar (closes #16)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,7 +11,7 @@ import path from "path";
 const args = process.argv.slice(2);
 const [command, ...rest] = args;
 
-const BOOLEAN_FLAGS = new Set(["json", "dryRun", "deny", "force"]);
+const BOOLEAN_FLAGS = new Set(["json", "dryRun", "deny", "force", "readOnly"]);
 
 function parseFlags(argv) {
   const flags = { positional: [] };
@@ -57,7 +57,8 @@ async function cmdServe(argv) {
   const flags = parseFlags(argv);
   const target = flags.claudeDir || flags.positional[0] || ".claude";
   const port = flags.port ? Number(flags.port) : 4000;
-  startServer({ claudeDir: target, port });
+  const readOnly = Boolean(flags.readOnly);
+  startServer({ claudeDir: target, port, readOnly });
 }
 
 async function cmdLint(argv) {
@@ -292,6 +293,8 @@ Usage:
   claude-atlas serve [path]        Start the interactive graph viewer
   claude-atlas serve [path] --port 4000
                                    Choose the HTTP port (default 4000)
+  claude-atlas serve [path] --read-only
+                                   Disable mutating endpoints (rename etc.)
 
 Defaults to ./.claude if no path is given.
 `);

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,11 +6,18 @@ import { fileURLToPath } from "url";
 import { scanClaudeDir } from "./scanner.js";
 import { lint } from "./linter.js";
 import { whoCan, rulesForAgent } from "./who-can.js";
+import { planRename, applyPlan } from "./rename.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const webDir = path.resolve(__dirname, "..", "web");
 
-export function createApp(claudeDir) {
+function isLocalhost(host) {
+  if (!host) return false;
+  const h = host.split(":")[0];
+  return h === "localhost" || h === "127.0.0.1" || h === "::1";
+}
+
+export function createApp(claudeDir, { readOnly = false } = {}) {
   const app = new Hono();
 
   app.get("/api/graph", async (c) => {
@@ -47,6 +54,43 @@ export function createApp(claudeDir) {
     }
   });
 
+  app.post("/api/rename", async (c) => {
+    if (readOnly) return c.json({ error: "Server is running in read-only mode." }, 403);
+
+    const host = c.req.header("host");
+    if (!isLocalhost(host)) {
+      return c.json({ error: "Rename is only allowed from localhost." }, 403);
+    }
+
+    let body;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body." }, 400);
+    }
+
+    const { old: oldName, new: newName, apply } = body;
+    if (!oldName || typeof oldName !== "string") return c.json({ error: "Missing field: old" }, 400);
+    if (!newName || typeof newName !== "string") return c.json({ error: "Missing field: new" }, 400);
+
+    try {
+      const graph = await scanClaudeDir(claudeDir);
+      const plan = await planRename(graph, oldName, newName);
+
+      if (apply === true) {
+        if (plan.collision) {
+          return c.json({ error: `Name "${newName}" collides with existing ${plan.collision.type} "${plan.collision.name}".`, plan }, 409);
+        }
+        const result = await applyPlan(plan);
+        return c.json({ applied: true, result, plan });
+      }
+
+      return c.json({ applied: false, plan });
+    } catch (err) {
+      return c.json({ error: err.message }, 500);
+    }
+  });
+
   app.use(
     "/*",
     serveStatic({
@@ -57,11 +101,12 @@ export function createApp(claudeDir) {
   return app;
 }
 
-export function startServer({ claudeDir, port = 4000 }) {
-  const app = createApp(claudeDir);
+export function startServer({ claudeDir, port = 4000, readOnly = false }) {
+  const app = createApp(claudeDir, { readOnly });
   return serve({ fetch: app.fetch, port }, (info) => {
     console.log(`claude-atlas viewer: http://localhost:${info.port}`);
     console.log(`  scanning: ${path.resolve(claudeDir)}`);
+    if (readOnly) console.log(`  read-only mode — mutations disabled`);
     console.log(`  Ctrl+C to stop`);
   });
 }

--- a/web/app.js
+++ b/web/app.js
@@ -480,6 +480,14 @@ function renderDetails(type, payload, id) {
   }
 
   if (type === "agent") {
+    parts.push(`
+      <div class="mt-3 mb-1">
+        <button data-rename-name="${escape(payload.name)}"
+          class="rename-btn inline-flex items-center gap-1.5 px-2.5 py-1 text-[11.5px] rounded-md border border-border bg-bg-2 text-fg-2 hover:text-fg hover:border-border-2 transition-colors">
+          Rename
+        </button>
+      </div>`);
+
     if (payload.tools?.length) {
       parts.push(sectionTitle("Tools", payload.tools.length));
       parts.push(`<div class="flex flex-wrap gap-1.5">` +
@@ -587,6 +595,197 @@ function wireClickThroughs(container) {
       showNode(target);
     });
   });
+
+  container.querySelectorAll(".rename-btn").forEach((btn) => {
+    btn.addEventListener("click", () => openRenameModal(btn.dataset.renameName));
+  });
+}
+
+/* ===== Rename modal ===== */
+const renameModal = document.getElementById("rename-modal");
+const renameOldEl = document.getElementById("rename-old");
+const renameNewEl = document.getElementById("rename-new");
+const renamePreviewBtn = document.getElementById("rename-preview");
+const renameApplyBtn = document.getElementById("rename-apply");
+const renameCancelBtn = document.getElementById("rename-cancel");
+const renameStatus = document.getElementById("rename-status");
+const renameDiffSection = document.getElementById("rename-diff-section");
+const renameDiffEl = document.getElementById("rename-diff");
+
+let pendingPlan = null;
+
+function openRenameModal(agentName) {
+  pendingPlan = null;
+  renameOldEl.value = agentName;
+  renameNewEl.value = "";
+  renameApplyBtn.disabled = true;
+  renameStatus.classList.add("hidden");
+  renameDiffSection.classList.add("hidden");
+  renameDiffEl.textContent = "";
+  renameModal.classList.remove("hidden");
+  renameNewEl.focus();
+}
+
+function closeRenameModal() {
+  renameModal.classList.add("hidden");
+  pendingPlan = null;
+}
+
+function setRenameStatus(msg, isError = false) {
+  renameStatus.textContent = msg;
+  renameStatus.className = `text-[12px] mb-3 ${isError ? "text-red-300" : "text-muted"}`;
+  renameStatus.classList.remove("hidden");
+}
+
+function renderDiffPreview(plan) {
+  if (!plan.changes.length) {
+    renameDiffEl.textContent = "(no changes — agent name not found in any file)";
+    return;
+  }
+  const lines = [];
+  let lastFile = null;
+  for (const ch of plan.changes) {
+    if (ch.file !== lastFile) {
+      if (lastFile !== null) lines.push("");
+      lines.push(`--- ${ch.file}`);
+      lastFile = ch.file;
+    }
+    lines.push(`L${ch.line}  - ${ch.before.trim()}`);
+    lines.push(`L${ch.line}  + ${ch.after.trim()}`);
+  }
+  renameDiffEl.textContent = lines.join("\n");
+}
+
+renameCancelBtn.addEventListener("click", closeRenameModal);
+
+renameNewEl.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") closeRenameModal();
+  if (e.key === "Enter") renamePreviewBtn.click();
+});
+
+renamePreviewBtn.addEventListener("click", async () => {
+  const oldName = renameOldEl.value.trim();
+  const newName = renameNewEl.value.trim();
+  if (!newName) { setRenameStatus("Enter a new name first.", true); return; }
+  if (newName === oldName) { setRenameStatus("New name is the same as the current name.", true); return; }
+
+  renamePreviewBtn.disabled = true;
+  renameApplyBtn.disabled = true;
+  renameDiffSection.classList.add("hidden");
+  setRenameStatus("Fetching preview…");
+
+  try {
+    const res = await fetch("/api/rename", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ old: oldName, new: newName, apply: false }),
+    });
+    const data = await res.json();
+    if (!res.ok) { setRenameStatus(data.error || `Server error ${res.status}`, true); return; }
+
+    pendingPlan = data.plan;
+
+    if (pendingPlan.collision) {
+      setRenameStatus(
+        `Cannot rename: "${newName}" collides with existing ${pendingPlan.collision.type} "${pendingPlan.collision.name}".`,
+        true
+      );
+      renameDiffSection.classList.remove("hidden");
+      renderDiffPreview(pendingPlan);
+      return;
+    }
+
+    const count = pendingPlan.changes.length;
+    setRenameStatus(`Preview: ${count} change(s) across ${new Set(pendingPlan.changes.map((c) => c.file)).size} file(s).`);
+    renameDiffSection.classList.remove("hidden");
+    renderDiffPreview(pendingPlan);
+    renameApplyBtn.disabled = false;
+  } catch (err) {
+    setRenameStatus(`Request failed: ${err.message}`, true);
+  } finally {
+    renamePreviewBtn.disabled = false;
+  }
+});
+
+renameApplyBtn.addEventListener("click", async () => {
+  const oldName = renameOldEl.value.trim();
+  const newName = renameNewEl.value.trim();
+  if (!newName || !pendingPlan) return;
+
+  renameApplyBtn.disabled = true;
+  renamePreviewBtn.disabled = true;
+  setRenameStatus("Applying rename…");
+
+  try {
+    const res = await fetch("/api/rename", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ old: oldName, new: newName, apply: true }),
+    });
+    const data = await res.json();
+    if (!res.ok) { setRenameStatus(data.error || `Server error ${res.status}`, true); renamePreviewBtn.disabled = false; return; }
+
+    setRenameStatus(`Renamed "${oldName}" to "${newName}" — refreshing graph…`);
+    closeRenameModal();
+    await refreshGraph();
+  } catch (err) {
+    setRenameStatus(`Request failed: ${err.message}`, true);
+    renamePreviewBtn.disabled = false;
+  }
+});
+
+async function refreshGraph() {
+  try {
+    [graph, findings] = await Promise.all([fetchJSON("/api/graph"), fetchJSON("/api/lint")]);
+  } catch (err) {
+    showLoadError(err.message);
+    return;
+  }
+
+  /* Rebuild cytoscape elements */
+  cy.elements().remove();
+
+  const newDegree = new Map();
+  for (const e of graph.edges) {
+    newDegree.set(e.from, (newDegree.get(e.from) || 0) + 1);
+    newDegree.set(e.to, (newDegree.get(e.to) || 0) + 1);
+  }
+  const newMaxDegree = Math.max(1, ...newDegree.values());
+  function newSizeFor(id) {
+    const d = newDegree.get(id) || 0;
+    return 14 + Math.round(46 * (d / newMaxDegree));
+  }
+
+  lintBySubject.clear();
+  for (const f of findings) {
+    if (!f.subject) continue;
+    const bucket = lintBySubject.get(f.subject) || { error: 0, warning: 0, info: 0 };
+    bucket[f.level] = (bucket[f.level] || 0) + 1;
+    lintBySubject.set(f.subject, bucket);
+  }
+
+  const newElements = [];
+  function addEl(id, label, type, payload) {
+    newElements.push({ data: { id, label, type, payload, size: newSizeFor(id), lint: lintLevel(id) } });
+  }
+  for (const a of graph.agents)     addEl(`agent:${a.slug}`,   a.name,       "agent",   a);
+  for (const c of graph.commands)   addEl(`command:${c.slug}`, `/${c.slug}`, "command", c);
+  for (const t of graph.tools)      addEl(`tool:${t.slug}`,    t.name,       "tool",    t);
+  for (const m of graph.mcpServers) addEl(`mcp:${m.slug}`,     m.name,       "mcp",     m);
+
+  let eid = 0;
+  for (const e of graph.edges) {
+    newElements.push({ data: { id: `e${eid++}`, source: e.from, target: e.to, kind: e.kind } });
+  }
+
+  cy.add(newElements);
+
+  document.getElementById("counts").textContent =
+    `${graph.agents.length} agents · ${graph.commands.length} commands · ${graph.tools.length} tools · ${graph.mcpServers.length} mcp`;
+
+  renderGlobalLint(findings);
+  applyLayout(currentMode);
+  showEmpty();
 }
 
 function renderGlobalLint(items) {

--- a/web/index.html
+++ b/web/index.html
@@ -68,6 +68,18 @@
       #side::-webkit-scrollbar-thumb { background: #22283a; border-radius: 4px; }
       #side::-webkit-scrollbar-thumb:hover { background: #2e3750; }
 
+      /* Rename modal */
+      #rename-modal {
+        position: absolute; inset: 0;
+        display: flex; flex-direction: column;
+        background: #000000;
+        z-index: 20;
+        padding: 20px;
+        overflow-y: auto;
+      }
+      #rename-modal.hidden { display: none; }
+      #rename-diff { font-family: ui-monospace, SFMono-Regular, monospace; font-size: 11.5px; white-space: pre-wrap; word-break: break-all; }
+
       /* Loading overlay */
       #loading {
         position: absolute; inset: 0;
@@ -179,6 +191,46 @@
           </h2>
           <div id="lint" class="space-y-1.5"></div>
         </div>
+
+        <!-- Rename modal — shown inside the sidebar, hidden by default -->
+        <div id="rename-modal" class="hidden">
+          <div class="flex items-center justify-between mb-4">
+            <h2 class="text-[13px] font-semibold tracking-tight">Rename agent</h2>
+            <button id="rename-cancel" class="text-[11.5px] text-muted hover:text-fg transition-colors">Cancel</button>
+          </div>
+
+          <div class="space-y-3 mb-4">
+            <div>
+              <label for="rename-old" class="block text-[10.5px] uppercase tracking-[0.08em] text-muted font-semibold mb-1">Current name</label>
+              <input id="rename-old" readonly
+                class="w-full bg-bg-2 border border-border text-fg-2 text-[12.5px] rounded-md px-3 py-1.5 cursor-not-allowed" />
+            </div>
+            <div>
+              <label for="rename-new" class="block text-[10.5px] uppercase tracking-[0.08em] text-muted font-semibold mb-1">New name</label>
+              <input id="rename-new" placeholder="Enter new name…"
+                class="w-full bg-bg-2 border border-border hover:border-border-2 focus:border-accent/60 focus:outline-none focus:ring-2 focus:ring-accent/20 text-fg text-[12.5px] rounded-md px-3 py-1.5 transition-colors" />
+            </div>
+          </div>
+
+          <div class="flex gap-2 mb-4">
+            <button id="rename-preview"
+              class="flex-1 px-3 py-1.5 text-[12px] rounded-md border border-border bg-bg-2 text-fg hover:border-border-2 hover:bg-panel-2 transition-colors">
+              Preview changes
+            </button>
+            <button id="rename-apply" disabled
+              class="flex-1 px-3 py-1.5 text-[12px] rounded-md border border-accent/40 bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-30 disabled:cursor-not-allowed">
+              Apply rename
+            </button>
+          </div>
+
+          <div id="rename-status" class="text-[12px] text-muted mb-3 hidden"></div>
+
+          <div id="rename-diff-section" class="hidden">
+            <h3 class="text-[10.5px] uppercase tracking-[0.08em] text-muted font-semibold mb-2">Diff preview</h3>
+            <div id="rename-diff" class="p-3 rounded-md border border-border bg-bg-2 text-fg leading-relaxed max-h-64 overflow-y-auto"></div>
+          </div>
+        </div>
+
       </aside>
 
     </div>


### PR DESCRIPTION
## Summary

- Adds a **Rename** button to agent detail panels in the viewer sidebar
- Two-step flow: preview shows every file that would change before anything is written
- Confirms rewrites `.claude/` files via existing `lib/rename.js` logic and auto-refreshes the graph
- `POST /api/rename` endpoint (loopback-only, `--read-only` flag returns 403)

## Test plan

- [ ] `node bin/cli.js serve .claude` — viewer boots, no errors
- [ ] Click an agent node → "Rename" button visible in sidebar
- [ ] Enter new name → preview shows diff summary
- [ ] Confirm → files rewritten, graph refreshes with new name
- [ ] `node bin/cli.js serve .claude --read-only` → rename button disabled / returns 403
- [ ] `node bin/cli.js scan .claude` still parses cleanly after rename

🤖 Generated with [Claude Code](https://claude.ai/claude-code)