### PR TITLE
feat: add --rule flag to lint for filtering by rule code (closes #28)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,7 +4,7 @@ import { lint } from "../lib/linter.js";
 import { startServer } from "../lib/server.js";
 import { planRename, applyPlan } from "../lib/rename.js";
 import { whoCan } from "../lib/who-can.js";
-import { formatFindingsGitHub } from "../lib/formatters.js";
+import { formatFindingsGitHub, filterFindings, VALID_RULE_CODES } from "../lib/formatters.js";
 import { initCi } from "../lib/init-ci.js";
 import path from "path";
 
@@ -61,11 +61,30 @@ async function cmdServe(argv) {
   startServer({ claudeDir: target, port, readOnly });
 }
 
+function parseRuleCodes(raw) {
+  if (!raw) return null;
+  const requested = raw.split(",").map((s) => s.trim()).filter(Boolean);
+  const unknown = requested.filter((c) => !VALID_RULE_CODES.includes(c));
+  if (unknown.length) {
+    console.error(`Unknown rule code(s): ${unknown.join(", ")}`);
+    console.error(`Valid codes: ${VALID_RULE_CODES.join(", ")}`);
+    process.exit(1);
+  }
+  return requested;
+}
+
 async function cmdLint(argv) {
   const flags = parseFlags(argv);
   const target = flags.claudeDir || flags.positional[0] || ".claude";
+  const ruleCodes = parseRuleCodes(flags.rule);
+
   const graph = await scanClaudeDir(target);
-  const findings = lint(graph);
+  let findings = lint(graph);
+
+  if (ruleCodes) {
+    findings = filterFindings(findings, ruleCodes);
+  }
+
   const hasErrors = findings.some((f) => f.level === "error");
 
   if (flags.format === "github") {
@@ -78,6 +97,10 @@ async function cmdLint(argv) {
     process.exit(hasErrors ? 1 : 0);
   }
 
+  printFindingsText(findings);
+}
+
+function printFindingsText(findings) {
   if (!findings.length) {
     console.log("✓ No issues found.");
     return;
@@ -273,6 +296,13 @@ Usage:
   claude-atlas lint [path] --format github
                                    Emit GitHub Actions workflow commands
                                    (PR annotations); exit 1 on errors
+  claude-atlas lint [path] --rule <codes>
+                                   Filter to specific rule codes only.
+                                   Accepts comma-separated list, e.g.:
+                                   --rule dead-agent,missing-description
+                                   Valid codes: dead-agent, missing-agent-ref,
+                                   missing-description, delegation-cycle,
+                                   unused-tool-grant, duplicate-candidate
 
   claude-atlas duplicates [path]   Show only duplicate-candidate findings,
                                    ranked by similarity score

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -9,6 +9,29 @@
  */
 import path from "path";
 
+/** All rule codes emitted by lib/linter.js — used to validate --rule input. */
+export const VALID_RULE_CODES = [
+  "dead-agent",
+  "missing-agent-ref",
+  "missing-description",
+  "delegation-cycle",
+  "unused-tool-grant",
+  "duplicate-candidate",
+];
+
+/**
+ * Filter findings to only those whose code is in the given set.
+ * Returns a new array; does not mutate the original.
+ *
+ * @param {Array} findings - raw findings from lint()
+ * @param {string[]} codes - rule codes to keep (all others are dropped)
+ * @returns {Array}
+ */
+export function filterFindings(findings, codes) {
+  const keep = new Set(codes);
+  return findings.filter((f) => keep.has(f.code));
+}
+
 const LEVEL_TO_CMD = {
   error: "error",
   warning: "warning",


### PR DESCRIPTION
## Summary
- Adds `--rule <codes>` option to `atlas lint` so teams can gate CI on specific rule codes incrementally
- Accepts comma-separated codes (e.g. `--rule dead-agent,missing-description`)
- Unknown codes exit 1 with a helpful message listing all valid codes
- Filter applies across all output formats: text, `--json`, and `--format github`

## Changes
- `lib/formatters.js`: adds `VALID_RULE_CODES` constant (all six rule codes) and `filterFindings(findings, codes)` helper that returns a filtered copy
- `bin/cli.js`: adds `parseRuleCodes()` that validates input against `VALID_RULE_CODES` and exits 1 on unknowns; wires `--rule` into `cmdLint()`; documents the flag in the usage text

## Verification
- [x] `node bin/cli.js lint test/fixtures/sample --rule dead-agent` shows only `dead-agent` findings (3 warnings, not 5)
- [x] `--rule missing-description,dead-agent` shows all 5 findings
- [x] `--rule dead-agent --json` returns a filtered JSON array
- [x] `--rule bogus-rule` prints `Unknown rule code(s): bogus-rule` + valid codes list, exits 1
- [x] `node bin/cli.js --help` documents the new flag

Closes #28