### PR TITLE
feat: unscoped-bash lint rule and workflows as a first-class graph node (closes #31)

### DIFF
--- a/.claude/workflows/fix-and-ship.md
+++ b/.claude/workflows/fix-and-ship.md
@@ -1,0 +1,19 @@
+---
+name: fix-and-ship
+description: End-to-end flow for picking up a GitHub issue, implementing the fix, reviewing the code, and opening a PR.
+---
+
+Run this workflow when you want to take a GitHub issue all the way to a pull request in one shot.
+
+## Steps
+
+1. **Pick up the issue** — Use the issue-manager to read the issue, plan the fix on a new branch, and implement it.
+
+2. **Review the changes** — Once the fix is committed, invoke code-reviewer to check the diff for quality issues, rule violations, and regressions against the scanner, linter, and web viewer.
+
+3. **Open the PR** — If the review passes (no blockers), use issue-manager to open the pull request against `main`, linking it to the original issue.
+
+## Notes
+
+- Always run `node bin/cli.js lint .claude` and `node bin/cli.js scan .claude` before opening the PR to confirm the atlas graph is still clean.
+- If code-reviewer flags any blockers, fix them before proceeding to step 3.

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -49,6 +49,7 @@ function resolveFile(graph, subject) {
   const [kind, slug] = subject.split(":");
   if (kind === "agent") return graph.agents.find((a) => a.slug === slug)?.file || null;
   if (kind === "command") return graph.commands.find((c) => c.slug === slug)?.file || null;
+  if (kind === "workflow") return (graph.workflows || []).find((w) => w.slug === slug)?.file || null;
   return null;
 }
 

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -17,6 +17,7 @@ export const VALID_RULE_CODES = [
   "delegation-cycle",
   "unused-tool-grant",
   "duplicate-candidate",
+  "unscoped-bash",
 ];
 
 /**

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -110,6 +110,23 @@ export function lint(graph) {
   findings.push(...detectDuplicateAgents(graph.agents));
   findings.push(...detectDuplicateCommands(graph.commands));
 
+  const hasBashAllow = (graph.permissions?.allow || []).some((r) =>
+    /^Bash\s*\(/i.test(r)
+  );
+  if (!hasBashAllow) {
+    for (const a of graph.agents) {
+      if (a.tools.some((t) => t.toLowerCase() === "bash")) {
+        findings.push({
+          level: "warning",
+          code: "unscoped-bash",
+          message: `Agent "${a.name}" has the Bash tool but no Bash(...) allow rule scopes what it can run. Add a scoped allow rule (e.g. Bash(git *)) to limit blast radius. See https://docs.anthropic.com/en/docs/claude-code/settings#permissions`,
+          subject: `agent:${a.slug}`,
+          line: a.lines?.tools ?? a.lines?.name ?? 1,
+        });
+      }
+    }
+  }
+
   return findings;
 }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -9,7 +9,7 @@
 export function lint(graph) {
   const findings = [];
   const agentSlugs = new Set(graph.agents.map((a) => a.slug));
-  const commandSlugs = new Set(graph.commands.map((c) => c.slug));
+  const workflows = graph.workflows || [];
 
   const referencedAgents = new Set();
   for (const e of graph.edges) {
@@ -54,6 +54,19 @@ export function lint(graph) {
       }
     }
   }
+  for (const w of workflows) {
+    for (const invoked of w.invokes) {
+      if (!agentSlugs.has(invoked)) {
+        findings.push({
+          level: "error",
+          code: "missing-agent-ref",
+          message: `Workflow "${w.name}" references unknown agent "${invoked}".`,
+          subject: `workflow:${w.slug}`,
+          line: w.lines?.name ?? 1,
+        });
+      }
+    }
+  }
 
   for (const a of graph.agents) {
     if (!a.description || !a.description.trim()) {
@@ -74,6 +87,17 @@ export function lint(graph) {
         message: `Command "/${c.slug}" has no description. Add frontmatter with a one-line description.`,
         subject: `command:${c.slug}`,
         line: c.lines?.name ?? 1,
+      });
+    }
+  }
+  for (const w of workflows) {
+    if (!w.description || !w.description.trim()) {
+      findings.push({
+        level: "warning",
+        code: "missing-description",
+        message: `Workflow "${w.name}" has no description. Add frontmatter with a one-line description.`,
+        subject: `workflow:${w.slug}`,
+        line: w.lines?.name ?? 1,
       });
     }
   }

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -134,16 +134,18 @@ export function lint(graph) {
   findings.push(...detectDuplicateAgents(graph.agents));
   findings.push(...detectDuplicateCommands(graph.commands));
 
-  const hasBashAllow = (graph.permissions?.allow || []).some((r) =>
-    /^Bash\s*\(/i.test(r)
-  );
+  // Bash(*) is a wildcard grant — equivalent to unscoped — so it does not suppress the warning.
+  const hasBashAllow = (graph.permissions?.allow || []).some((r) => {
+    const m = r.match(/^Bash\s*\(\s*(.*?)\s*\)\s*$/i);
+    return m && m[1] !== "*";
+  });
   if (!hasBashAllow) {
     for (const a of graph.agents) {
       if (a.tools.some((t) => t.toLowerCase() === "bash")) {
         findings.push({
           level: "warning",
           code: "unscoped-bash",
-          message: `Agent "${a.name}" has the Bash tool but no Bash(...) allow rule scopes what it can run. Add a scoped allow rule (e.g. Bash(git *)) to limit blast radius. See https://docs.anthropic.com/en/docs/claude-code/settings#permissions`,
+          message: `Agent "${a.name}" has the Bash tool but this project has no scoped Bash(...) allow rule in settings.json. Add a scoped allow rule (e.g. Bash(git *)) to limit blast radius. See https://docs.anthropic.com/en/docs/claude-code/settings#permissions`,
           subject: `agent:${a.slug}`,
           line: a.lines?.tools ?? a.lines?.name ?? 1,
         });

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -101,6 +101,7 @@ export async function scanClaudeDir(claudeDir) {
 
   const rawAgents = await readMdFiles(path.join(absClaude, "agents"));
   const rawCommands = await readMdFiles(path.join(absClaude, "commands"));
+  const rawWorkflows = await readMdFiles(path.join(absClaude, "workflows"));
   const mcpServers = await readMcpServers(repoRoot);
   const permissions = await readSettingsPermissions(absClaude);
 
@@ -133,6 +134,7 @@ export async function scanClaudeDir(claudeDir) {
 
   const agents = rawAgents.map((f) => buildDoc(f, true));
   const commands = rawCommands.map((f) => buildDoc(f, false));
+  const workflows = rawWorkflows.map((f) => buildDoc(f, false));
 
   const agentByLowerName = new Map(agents.map((a) => [a.name.toLowerCase(), a]));
 
@@ -178,6 +180,11 @@ export async function scanClaudeDir(claudeDir) {
     c.invokesOrdered = ordered;
     c.invokes = ordered.map((h) => h.slug);
   }
+  for (const w of workflows) {
+    const ordered = detectAgentMentions(w.body, w.lines.body);
+    w.invokesOrdered = ordered;
+    w.invokes = ordered.map((h) => h.slug);
+  }
 
   const edges = [];
   for (const a of agents) {
@@ -193,12 +200,18 @@ export async function scanClaudeDir(claudeDir) {
       edges.push({ from: `command:${c.slug}`, to: `agent:${invoked}`, kind: "invokes" });
     }
   }
+  for (const w of workflows) {
+    for (const invoked of w.invokes) {
+      edges.push({ from: `workflow:${w.slug}`, to: `agent:${invoked}`, kind: "invokes" });
+    }
+  }
 
   return {
     claudeDir: absClaude,
     scannedAt: new Date().toISOString(),
     agents,
     commands,
+    workflows,
     tools: [...toolGrants.values()],
     mcpServers: mcpServers.map((s) => ({ slug: slug(s), name: s })),
     permissions,

--- a/test/fixtures/bad-ref/workflows/broken.md
+++ b/test/fixtures/bad-ref/workflows/broken.md
@@ -1,0 +1,6 @@
+---
+name: broken
+description: References a nonexistent agent.
+---
+
+This workflow invokes the ghost-agent to do some work.

--- a/test/fixtures/sample/workflows/deploy.md
+++ b/test/fixtures/sample/workflows/deploy.md
@@ -1,0 +1,10 @@
+---
+name: deploy
+description: Full deploy pipeline from plan to ship.
+---
+
+Run the deploy workflow when a feature is ready to ship.
+
+First, invoke the planner to sketch the approach. Once the plan is approved,
+hand off to the writer to implement the changes. Then ask the reviewer to
+check the diff before pushing.

--- a/test/fixtures/unscoped-bash/agents/runner.md
+++ b/test/fixtures/unscoped-bash/agents/runner.md
@@ -1,0 +1,7 @@
+---
+name: runner
+description: Runs shell commands to execute tasks.
+tools: [Bash]
+---
+
+Runs shell commands to execute tasks.

--- a/test/fixtures/unscoped-bash/settings.json
+++ b/test/fixtures/unscoped-bash/settings.json
@@ -1,0 +1,6 @@
+{
+  "permissions": {
+    "allow": [],
+    "deny": []
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -489,6 +489,39 @@ describe("who-can", () => {
 });
 
 // ---------------------------------------------------------------------------
+// linter: unscoped-bash rule
+// ---------------------------------------------------------------------------
+
+describe("linter — unscoped-bash rule", () => {
+  const UNSCOPED = path.join(FIXTURES, "unscoped-bash");
+
+  it("fires when agent has Bash tool and no Bash(...) allow rule", async () => {
+    const graph = await scanClaudeDir(UNSCOPED);
+    const findings = lint(graph);
+    const f = findings.filter((x) => x.code === "unscoped-bash");
+    assert.ok(f.length >= 1, "expected at least one unscoped-bash finding");
+    assert.equal(f[0].level, "warning");
+    assert.ok(f[0].message.includes("runner"), "message should name the agent");
+  });
+
+  it("is suppressed when a scoped Bash allow rule exists", async () => {
+    const graph = await scanClaudeDir(UNSCOPED);
+    graph.permissions.allow = ["Bash(git *)"];
+    const findings = lint(graph);
+    const f = findings.filter((x) => x.code === "unscoped-bash");
+    assert.equal(f.length, 0, "unscoped-bash should not fire when Bash(git *) allow exists");
+  });
+
+  it("is suppressed when a wildcard Bash(*) allow rule exists", async () => {
+    const graph = await scanClaudeDir(UNSCOPED);
+    graph.permissions.allow = ["Bash(*)"];
+    const findings = lint(graph);
+    const f = findings.filter((x) => x.code === "unscoped-bash");
+    assert.equal(f.length, 0, "unscoped-bash should not fire when Bash(*) allow exists");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Utility
 // ---------------------------------------------------------------------------
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -121,6 +121,32 @@ describe("scanner", () => {
       /No \.claude directory/
     );
   });
+
+  it("returns workflows array", () => {
+    assert.ok(Array.isArray(graph.workflows), "graph.workflows should be an array");
+    assert.ok(graph.workflows.length >= 1, "expected at least one workflow in sample");
+  });
+
+  it("parses workflow frontmatter: name, description", () => {
+    const deploy = graph.workflows.find((w) => w.slug === "deploy");
+    assert.ok(deploy, "deploy workflow not found");
+    assert.equal(deploy.name, "deploy");
+    assert.equal(deploy.description, "Full deploy pipeline from plan to ship.");
+  });
+
+  it("detects workflow invoking agents via prose mention", () => {
+    const deploy = graph.workflows.find((w) => w.slug === "deploy");
+    assert.ok(deploy.invokes.includes("planner"), "deploy should invoke planner");
+    assert.ok(deploy.invokes.includes("writer"), "deploy should invoke writer");
+    assert.ok(deploy.invokes.includes("reviewer"), "deploy should invoke reviewer");
+  });
+
+  it("emits workflow→agent invokes edges", () => {
+    const wfEdges = graph.edges.filter((e) => e.from === "workflow:deploy" && e.kind === "invokes");
+    assert.ok(wfEdges.length >= 1, "expected invokes edges from workflow:deploy");
+    const targets = wfEdges.map((e) => e.to);
+    assert.ok(targets.includes("agent:planner"), "should have edge to agent:planner");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -214,6 +240,27 @@ describe("linter", () => {
       const errors = findings.filter((f) => f.code === "missing-agent-ref");
       assert.equal(errors.length, 0, "sample has no bad refs");
     });
+
+    it("fires when a workflow references a nonexistent agent", async () => {
+      const graph = makeGraph({
+        workflows: [
+          {
+            slug: "broken",
+            name: "broken",
+            description: "References a ghost agent.",
+            invokes: ["ghost-agent"],
+            body: "",
+            lines: { name: 1 },
+          },
+        ],
+        edges: [{ from: "workflow:broken", to: "agent:ghost-agent", kind: "invokes" }],
+      });
+      const findings = lint(graph);
+      const errors = findings.filter(
+        (f) => f.code === "missing-agent-ref" && f.subject === "workflow:broken"
+      );
+      assert.ok(errors.length >= 1, "expected missing-agent-ref for workflow referencing nonexistent agent");
+    });
   });
 
   describe("missing-description rule", () => {
@@ -239,6 +286,24 @@ describe("linter", () => {
       const noDesc = findings.filter((f) => f.code === "missing-description");
       const subjects = noDesc.map((f) => f.subject);
       assert.ok(!subjects.includes("agent:planner"), "planner has description, should not fire");
+    });
+
+    it("fires for workflow with no description", () => {
+      const graph = makeGraph({
+        workflows: [
+          {
+            slug: "nodesc",
+            name: "nodesc",
+            description: "",
+            invokes: [],
+            body: "Does something.",
+            lines: { name: 1 },
+          },
+        ],
+      });
+      const findings = lint(graph);
+      const f = findings.filter((x) => x.code === "missing-description" && x.subject === "workflow:nodesc");
+      assert.ok(f.length >= 1, "expected missing-description for workflow with no description");
     });
   });
 
@@ -512,12 +577,12 @@ describe("linter — unscoped-bash rule", () => {
     assert.equal(f.length, 0, "unscoped-bash should not fire when Bash(git *) allow exists");
   });
 
-  it("is suppressed when a wildcard Bash(*) allow rule exists", async () => {
+  it("is NOT suppressed when only a wildcard Bash(*) allow rule exists", async () => {
     const graph = await scanClaudeDir(UNSCOPED);
     graph.permissions.allow = ["Bash(*)"];
     const findings = lint(graph);
     const f = findings.filter((x) => x.code === "unscoped-bash");
-    assert.equal(f.length, 0, "unscoped-bash should not fire when Bash(*) allow exists");
+    assert.ok(f.length >= 1, "Bash(*) is an unrestricted grant and should not suppress unscoped-bash");
   });
 });
 

--- a/web/app.js
+++ b/web/app.js
@@ -36,10 +36,20 @@ const nodeColor = {
   command: "#f4a261",
   tool: "#84d9a8",
   mcp: "#c08cf8",
+  workflow: "#f472b6",
 };
 
-document.getElementById("counts").textContent =
-  `${graph.agents.length} agents · ${graph.commands.length} commands · ${graph.tools.length} tools · ${graph.mcpServers.length} mcp`;
+function countsText(g) {
+  const parts = [
+    `${g.agents.length} agents`,
+    `${g.commands.length} commands`,
+    `${g.tools.length} tools`,
+    `${g.mcpServers.length} mcp`,
+  ];
+  if ((g.workflows || []).length) parts.splice(1, 0, `${g.workflows.length} workflows`);
+  return parts.join(" · ");
+}
+document.getElementById("counts").textContent = countsText(graph);
 
 /* ===== Compute degree + lint-by-subject maps ===== */
 const degree = new Map();
@@ -81,10 +91,11 @@ function addNode(id, label, type, payload) {
   });
 }
 
-for (const a of graph.agents)     addNode(`agent:${a.slug}`,   a.name,       "agent",   a);
-for (const c of graph.commands)   addNode(`command:${c.slug}`, `/${c.slug}`, "command", c);
-for (const t of graph.tools)      addNode(`tool:${t.slug}`,    t.name,       "tool",    t);
-for (const m of graph.mcpServers) addNode(`mcp:${m.slug}`,     m.name,       "mcp",     m);
+for (const a of graph.agents)              addNode(`agent:${a.slug}`,    a.name,       "agent",    a);
+for (const c of graph.commands)            addNode(`command:${c.slug}`,  `/${c.slug}`, "command",  c);
+for (const w of (graph.workflows || []))   addNode(`workflow:${w.slug}`, w.name,       "workflow", w);
+for (const t of graph.tools)               addNode(`tool:${t.slug}`,     t.name,       "tool",     t);
+for (const m of graph.mcpServers)          addNode(`mcp:${m.slug}`,      m.name,       "mcp",      m);
 
 let edgeId = 0;
 for (const e of graph.edges) {
@@ -251,7 +262,7 @@ if (document.readyState === "complete") {
    Types with more than MAX_PER_ROW nodes wrap onto sub-rows so individual
    nodes stay readable and labels don't collide. */
 function tieredLayoutConfig() {
-  const tiers = ["agent", "command", "tool", "mcp"];
+  const tiers = ["workflow", "agent", "command", "tool", "mcp"];
   const MAX_PER_ROW = 10;
   const w = cy.width();
   const h = cy.height();
@@ -295,16 +306,17 @@ function tieredLayoutConfig() {
    Arrows between nodes of the same type radiate around a center
    instead of stacking on a shared axis. */
 function groupsLayoutConfig() {
-  const types = ["agent", "command", "tool", "mcp"];
+  const types = ["workflow", "agent", "command", "tool", "mcp"];
   const w = cy.width();
   const h = cy.height();
   const positions = {};
 
   const centers = {
-    agent:   { x: w * 0.28, y: h * 0.30 },
-    command: { x: w * 0.72, y: h * 0.30 },
-    tool:    { x: w * 0.28, y: h * 0.72 },
-    mcp:     { x: w * 0.72, y: h * 0.72 },
+    workflow: { x: w * 0.5, y: h * 0.15 },
+    agent:    { x: w * 0.28, y: h * 0.42 },
+    command:  { x: w * 0.72, y: h * 0.42 },
+    tool:     { x: w * 0.28, y: h * 0.78 },
+    mcp:      { x: w * 0.72, y: h * 0.78 },
   };
 
   const quadrant = Math.min(w, h) / 2;
@@ -457,6 +469,56 @@ function showNode(node) {
   wireClickThroughs(side.details);
 }
 
+function renderInvokesSection(payload) {
+  if (!payload.invokes?.length) return [];
+  return [
+    sectionTitle("Invokes", payload.invokes.length),
+    `<div class="space-y-1.5">` + invokeListHTML(payload) + `</div>`,
+  ];
+}
+
+function renderTypeDetails(type, payload) {
+  if (type === "agent") {
+    const renameBtn = `
+      <div class="mt-3 mb-1">
+        <button data-rename-name="${escape(payload.name)}"
+          class="rename-btn inline-flex items-center gap-1.5 px-2.5 py-1 text-[11.5px] rounded-md border border-border bg-bg-2 text-fg-2 hover:text-fg hover:border-border-2 transition-colors">
+          Rename
+        </button>
+      </div>`;
+    const toolsSection = payload.tools?.length
+      ? [sectionTitle("Tools", payload.tools.length),
+         `<div class="flex flex-wrap gap-1.5">` + payload.tools.map((t) => tagPill(t, `tool:${slug(t)}`)).join("") + `</div>`]
+      : [];
+    const invokedBy = graph.edges
+      .filter((e) => e.to === `agent:${payload.slug}` && e.kind === "invokes")
+      .map((e) => e.from);
+    const invokedBySection = invokedBy.length
+      ? [sectionTitle("Invoked by", invokedBy.length),
+         `<div class="space-y-1.5">` + invokedBy.map(cardHTML).join("") + `</div>`]
+      : [];
+    const rules = payload.applicableRules;
+    const permSection = rules && (rules.allowedBy.length || rules.deniedBy.length)
+      ? [sectionTitle("Permissions", rules.allowedBy.length + rules.deniedBy.length),
+         `<div class="flex flex-wrap gap-1.5">` +
+           rules.allowedBy.map((r) => rulePill(r, "allow")).join("") +
+           rules.deniedBy.map((r) => rulePill(r, "deny")).join("") +
+         `</div>`]
+      : [];
+    return [renameBtn, ...toolsSection, ...renderInvokesSection(payload), ...invokedBySection, ...permSection];
+  }
+  if (type === "tool") {
+    return [
+      sectionTitle("Granted to", (payload.agents || []).length),
+      `<div class="space-y-1.5">` + (payload.agents || []).map((s) => cardHTML(`agent:${s}`)).join("") + `</div>`,
+    ];
+  }
+  if (type === "command" || type === "workflow") {
+    return renderInvokesSection(payload);
+  }
+  return [];
+}
+
 function renderDetails(type, payload, id) {
   const parts = [];
   const color = nodeColor[type];
@@ -479,54 +541,7 @@ function renderDetails(type, payload, id) {
     parts.push(`<div class="space-y-1.5">${nodeLint.map(renderLintRow).join("")}</div>`);
   }
 
-  if (type === "agent") {
-    parts.push(`
-      <div class="mt-3 mb-1">
-        <button data-rename-name="${escape(payload.name)}"
-          class="rename-btn inline-flex items-center gap-1.5 px-2.5 py-1 text-[11.5px] rounded-md border border-border bg-bg-2 text-fg-2 hover:text-fg hover:border-border-2 transition-colors">
-          Rename
-        </button>
-      </div>`);
-
-    if (payload.tools?.length) {
-      parts.push(sectionTitle("Tools", payload.tools.length));
-      parts.push(`<div class="flex flex-wrap gap-1.5">` +
-        payload.tools.map((t) => tagPill(t, `tool:${slug(t)}`)).join("") + `</div>`);
-    }
-    if (payload.invokes?.length) {
-      parts.push(sectionTitle("Invokes", payload.invokes.length));
-      parts.push(`<div class="space-y-1.5">` + invokeListHTML(payload) + `</div>`);
-    }
-    const invokedBy = graph.edges
-      .filter((e) => e.to === `agent:${payload.slug}` && e.kind === "invokes")
-      .map((e) => e.from);
-    if (invokedBy.length) {
-      parts.push(sectionTitle("Invoked by", invokedBy.length));
-      parts.push(`<div class="space-y-1.5">` + invokedBy.map(cardHTML).join("") + `</div>`);
-    }
-    const rules = payload.applicableRules;
-    if (rules && (rules.allowedBy.length || rules.deniedBy.length)) {
-      const total = rules.allowedBy.length + rules.deniedBy.length;
-      parts.push(sectionTitle("Permissions", total));
-      parts.push(`<div class="flex flex-wrap gap-1.5">` +
-        rules.allowedBy.map((r) => rulePill(r, "allow")).join("") +
-        rules.deniedBy.map((r) => rulePill(r, "deny")).join("") +
-        `</div>`);
-    }
-  }
-
-  if (type === "tool") {
-    parts.push(sectionTitle("Granted to", (payload.agents || []).length));
-    parts.push(`<div class="space-y-1.5">` + (payload.agents || []).map((s) => cardHTML(`agent:${s}`)).join("") + `</div>`);
-  }
-
-  if (type === "command") {
-    if (payload.invokes?.length) {
-      parts.push(sectionTitle("Invokes", payload.invokes.length));
-      parts.push(`<div class="space-y-1.5">` + invokeListHTML(payload) + `</div>`);
-    }
-  }
-
+  parts.push(...renderTypeDetails(type, payload));
   return parts.join("");
 }
 
@@ -768,10 +783,11 @@ async function refreshGraph() {
   function addEl(id, label, type, payload) {
     newElements.push({ data: { id, label, type, payload, size: newSizeFor(id), lint: lintLevel(id) } });
   }
-  for (const a of graph.agents)     addEl(`agent:${a.slug}`,   a.name,       "agent",   a);
-  for (const c of graph.commands)   addEl(`command:${c.slug}`, `/${c.slug}`, "command", c);
-  for (const t of graph.tools)      addEl(`tool:${t.slug}`,    t.name,       "tool",    t);
-  for (const m of graph.mcpServers) addEl(`mcp:${m.slug}`,     m.name,       "mcp",     m);
+  for (const a of graph.agents)              addEl(`agent:${a.slug}`,    a.name,       "agent",    a);
+  for (const c of graph.commands)            addEl(`command:${c.slug}`,  `/${c.slug}`, "command",  c);
+  for (const w of (graph.workflows || []))   addEl(`workflow:${w.slug}`, w.name,       "workflow", w);
+  for (const t of graph.tools)               addEl(`tool:${t.slug}`,     t.name,       "tool",     t);
+  for (const m of graph.mcpServers)          addEl(`mcp:${m.slug}`,      m.name,       "mcp",      m);
 
   let eid = 0;
   for (const e of graph.edges) {
@@ -780,8 +796,7 @@ async function refreshGraph() {
 
   cy.add(newElements);
 
-  document.getElementById("counts").textContent =
-    `${graph.agents.length} agents · ${graph.commands.length} commands · ${graph.tools.length} tools · ${graph.mcpServers.length} mcp`;
+  document.getElementById("counts").textContent = countsText(graph);
 
   renderGlobalLint(findings);
   applyLayout(currentMode);

--- a/web/index.html
+++ b/web/index.html
@@ -24,6 +24,7 @@
               command: "#f4a261",
               tool: "#84d9a8",
               mcp: "#c08cf8",
+              workflow: "#f472b6",
               accent: "#7aa7ff",
             },
             fontFamily: {
@@ -122,6 +123,9 @@
           </button>
           <button data-type="command" class="chip inline-flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-full border border-border hover:border-border-2 bg-bg-2 text-fg-2 hover:text-fg transition-colors">
             <span class="swatch-ring w-2 h-2 rounded-full bg-command"></span>commands
+          </button>
+          <button data-type="workflow" class="chip inline-flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-full border border-border hover:border-border-2 bg-bg-2 text-fg-2 hover:text-fg transition-colors">
+            <span class="swatch-ring w-2 h-2 rounded-full bg-workflow"></span>workflows
           </button>
           <button data-type="tool" class="chip inline-flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-full border border-border hover:border-border-2 bg-bg-2 text-fg-2 hover:text-fg transition-colors">
             <span class="swatch-ring w-2 h-2 rounded-full bg-tool"></span>tools


### PR DESCRIPTION
## Summary

- Adds `unscoped-bash` lint rule (`warning`) in `lib/linter.js`: fires when an agent holds the `Bash` tool but `settings.json` has no scoped `Bash(...)` allow rule; suppressed by any scoped pattern, not by a bare `Bash(*)` wildcard
- Introduces **workflows** as a first-class node type: `lib/scanner.js` reads `.claude/workflows/*.md`, builds a `workflows` array in the graph, and emits `workflow→agent` invokes edges
- Extends `lib/linter.js` to run `missing-agent-ref` and `missing-description` checks against workflow nodes
- Updates `lib/formatters.js`: adds `"unscoped-bash"` to `VALID_RULE_CODES`; extends `resolveFile` to resolve `workflow:` subjects to source files for `--format github` annotations
- Updates `web/app.js` and `web/index.html`: renders workflow nodes (pink, `#f472b6`), adds them to the counts bar, and places them in their own top tier in both tiered and groups layouts
- Adds fixtures (`test/fixtures/unscoped-bash/`, `test/fixtures/sample/workflows/`, `test/fixtures/bad-ref/workflows/`) and 10 new test cases covering scanner workflow parsing, edge emission, linter workflow checks, and all three `unscoped-bash` branches

## Changes

- `lib/scanner.js`: reads `workflows/*.md`, calls `detectAgentMentions` on workflow prose, attaches `invokes`/edges, includes `workflows` in the returned graph object
- `lib/linter.js`: `missing-agent-ref` and `missing-description` extended to workflows; `unscoped-bash` rule added with wildcard-Bash guard
- `lib/formatters.js`: `unscoped-bash` added to valid rule codes; `resolveFile` handles `workflow:` prefix
- `web/app.js`: workflow nodes rendered and positioned; counts text updated; `tieredLayoutConfig` and `groupsLayoutConfig` include workflows tier
- `web/index.html`: legend entry for workflow node colour
- `.claude/workflows/fix-and-ship.md`: example workflow file in the repo's own `.claude/`

## Verification

- [ ] `npm test` — all tests pass (62/62 after this branch)
- [ ] `node bin/cli.js lint ./test/fixtures/unscoped-bash` — fires one `unscoped-bash` warning
- [ ] `node bin/cli.js lint ./test/fixtures/bad-ref` — fires `missing-agent-ref` for the broken workflow
- [ ] `node bin/cli.js scan ./test/fixtures/sample --json | jq .workflows` — returns the deploy workflow node
- [ ] `node bin/cli.js serve ./test/fixtures/sample` + open viewer — workflow node visible in pink

Closes #31